### PR TITLE
Allow running non-steam scummvm games

### DIFF
--- a/run-vm
+++ b/run-vm
@@ -109,10 +109,11 @@ def run_scummvm():
     log('working dir: "{}"'.format(os.getcwd()))
     cmd = settings.get_scummvm_cmd()
     install_dir = toolbox.guess_game_install_dir()
-    if install_dir:
-        cmd = [x.replace('%install_dir%', install_dir) for x in cmd]
-    else:
+    if not install_dir:
         log_warn('unrecognized installation directory')
+        install_dir = os.getcwd()
+
+    cmd = [x.replace('%install_dir%', install_dir) for x in cmd]
 
     # install_dir has some escaped characters (on purpose)
     # TODO: split escaping into a separate function


### PR DESCRIPTION
Not sure if this is outside the scope of the project but a small change allows people to use steam to launch native non-steam scummvm games.

e.g.

1) Download/extract Lure of the Temptress
2) Use [steamtinkerlaunch](https://github.com/frostworx/steamtinkerlaunch) to add the game to steam
3) Set the App Name and the Start dir to be where you extracted the game

Then just relaunch steam and set the game compatibility to roberta

![image](https://user-images.githubusercontent.com/1236338/121781815-6da91180-cb9e-11eb-909b-506e0e6d0b5b.png)

Even without this change, I think there needs to be a change to the handling of what to do if guess_game_install_dir fails. At the moment it returns None which then makes it fall over when it tries to do

`
install_dir = install_dir.replace('\\ ', ' ')
`

Setting install_dir to cwd seems like a ok default and also makes this work with non steam games as I said above :smile: 